### PR TITLE
Hotfix 20170517

### DIFF
--- a/app/loader.js
+++ b/app/loader.js
@@ -1,3 +1,3 @@
 var scriptElement = document.createElement('script');
-scriptElement.setAttribute('src', chrome.extension.getURL('scripts/contents.js'));
+scriptElement.setAttribute('src', chrome.runtime.getURL('scripts/contents.js'));
 document.documentElement.appendChild(scriptElement);

--- a/app/styles.scss/main.scss
+++ b/app/styles.scss/main.scss
@@ -5,3 +5,6 @@
   padding: 5px 0;
   cursor: pointer;
 }
+#SimpleAllBtn:hover{
+  text-decoration: underline;
+}


### PR DESCRIPTION
ボタンが表示されない問題に対応しました。

原因は、[chromeのバージョン](https://developer.chrome.com/extensions/extension#method-getURL)によってメソッドが廃止されるためでした。

> Deprecated since Chrome 58. Please use runtime.getURL.

ついでに、「ニックネームの設定」ボタンと合わせて
スタイルも追加しました。